### PR TITLE
バグ修正

### DIFF
--- a/bench/bat.mac
+++ b/bench/bat.mac
@@ -3,12 +3,6 @@
 /run/verbose 0
 
 # change world parameter
-/usr/det/setMaterial NaI
-/usr/det/setShieldMaterial Water
-/usr/det/setSensorRadius 10 cm
-/usr/det/setSensorHeight 20 cm
-/usr/det/setShieldThickness 1 cm
-/usr/det/setField 0.0 tesla
 /usr/det/setMaxStep  1.0 cm
 
 #inactivate msc

--- a/bench/run.mac
+++ b/bench/run.mac
@@ -3,12 +3,6 @@
 /run/verbose 1
 
 # change world parameter
-/usr/det/setMaterial NaI
-/usr/det/setShieldMaterial Water
-/usr/det/setSensorRadius 10 cm
-/usr/det/setSensorHeight 20 cm
-/usr/det/setShieldThickness 1 cm
-/usr/det/setField 0.0 tesla
 /usr/det/setMaxStep  1.0 cm
 
 #inactivate msc

--- a/mc/src/mcDetectorConstruction.cc
+++ b/mc/src/mcDetectorConstruction.cc
@@ -28,7 +28,7 @@
 
 mcDetectorConstruction::mcDetectorConstruction()
     : defaultMaterial(0), sensorMaterial(0), shieldMaterial(0),
-      WorldRadius(5.0 * m), sensorRadius(5.0 * cm), sensorHeight(2.5 * mm), shieldThickness(1 * cm),
+      WorldRadius(15.0 * m), sensorRadius(5.0 * cm), sensorHeight(2.5 * mm), shieldThickness(1 * cm),
       solidWorld(0), logicWorld(0), physWorld(0),
       solidSensor(0), logicSensor(0), physSensor(0),
       magField(0), pUserLimits(0), maxStep(100.0 * cm)


### PR DESCRIPTION
mcDetectorConstruction内で, マクロから値を読んでいるのが間違っている.
多分マクロの数字に依存しないように書き直した方がいい.
一応テストは通るが, 再現するマクロのテストはコケる.
Detector Constructionが外から入れるパラメーターに依存しないように作り直すべし.
とりあえずマクロの行を消せば動く.